### PR TITLE
Add ability to pass url and token as prop for Databrowser V2

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 ## Components
 
 - [Redis CLI](https://github.com/upstash/react-ui/blob/main/packages/react-cli/README.md)
+- [Redis Databrowser](https://github.com/upstash/react-ui/blob/main/packages/react-databrowser/README.md)
 
 
 <br/>
@@ -43,7 +44,7 @@ pnpm build
 This will prompt you to select which packages have changed. It will also create a changeset file in the `.changeset` directory.
 2. Run `pnpm changeset version`
 This will bump the versions of the packages previously specified with pnpm changeset (and any dependents of those) and update the changelog files.
-3. Run `pnpm install` 
+3. Run `pnpm install`
 This will update the lockfile and rebuild packages.
 4. Commit the changes
 5. Run `pnpm publish -r`

--- a/examples/nextjs13/CHANGELOG.md
+++ b/examples/nextjs13/CHANGELOG.md
@@ -1,5 +1,12 @@
 # nextjs13
 
+## 0.1.20
+
+### Patch Changes
+
+- Updated dependencies
+  - @upstash/react-databrowser@0.0.3
+
 ## 0.1.19
 
 ### Patch Changes

--- a/examples/nextjs13/app/databrowser/page.tsx
+++ b/examples/nextjs13/app/databrowser/page.tsx
@@ -3,6 +3,15 @@ import { Databrowser } from "@upstash/react-databrowser";
 import "@upstash/react-databrowser/dist/index.css";
 
 export default function DatabrowserDemo() {
+  const upstashRedisRestUrl = process.env.NEXT_PUBLIC_UPSTASH_REDIS_REST_URL;
+  if (!upstashRedisRestUrl) {
+    return <div>UPSTASH_REDIS_REST_URL not set </div>;
+  }
+  const upstashRedisRestToken = process.env.NEXT_PUBLIC_UPSTASH_REDIS_REST_TOKEN;
+  if (!upstashRedisRestToken) {
+    return <div>UPSTASH_REDIS_REST_TOKEN not set </div>;
+  }
+
   return (
     <main
       style={{
@@ -25,7 +34,7 @@ export default function DatabrowserDemo() {
           overflow: "hidden",
         }}
       >
-        <Databrowser />
+        <Databrowser url={upstashRedisRestUrl} token={upstashRedisRestToken} />
       </div>
     </main>
   );

--- a/examples/nextjs13/package.json
+++ b/examples/nextjs13/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextjs13",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/packages/react-databrowser/CHANGELOG.md
+++ b/packages/react-databrowser/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @upstash/react-databrowser
 
+## 0.0.3
+
+### Patch Changes
+
+- Allow passing token and url as a prop addition to env keys
+
 ## 0.0.2
 
 ### Patch Changes

--- a/packages/react-databrowser/README.md
+++ b/packages/react-databrowser/README.md
@@ -19,8 +19,6 @@
 - [Install](#1-install)
 - [Configuration](#2-configuration)
 - [Usage](#3-usage)
-- [Security Notice](#security-notice)
-- [Support and Contribution](#support-and-contribution)
 
 ## 1. Install
 
@@ -65,7 +63,6 @@ export default function DatabrowserDemo() {
   );
 }
 
-// Example CSS-in-JS styling
 const mainStyle = {
   height: "100vh",
   width: "100vw",

--- a/packages/react-databrowser/README.md
+++ b/packages/react-databrowser/README.md
@@ -1,62 +1,88 @@
-<div align="center">
-    <h1 align="center">@upstash/react-databrowser</h1>
-    <h5>Databrowser for Upstash Redis</h5>
-</div>
+# @upstash/react-databrowser
 
-<div align="center">
-  <a href="https://upstash-react-cli.vercel.app/">upstash-react-cli.vercel.app</a>
-</div>
-<br/>
+<p align="center">
+    <h2 align="center">Databrowser for Upstash Redis</h2>
+</p>
 
+<p align="center">
+    <a href="https://upstash-react-cli.vercel.app/">Explore the demo application</a>
+</p>
+
+---
+
+## Introduction
+
+`@upstash/react-databrowser` is a React component that provides a UI for browsing data in your Upstash Redis instances. It’s easy to set up and integrate into your React applications. This guide will help you get started with the installation and basic usage.
+
+## Table of Contents
+
+- [Install](#1-install)
+- [Configuration](#2-configuration)
+- [Usage](#3-usage)
+- [Security Notice](#security-notice)
+- [Support and Contribution](#support-and-contribution)
 
 ## 1. Install
+
+Install the databrowser component via npm:
 
 ```sh-session
 $ npm install @upstash/react-databrowser
 ```
 
-## 2. Add env keys
-```sh-session
-NEXT_PUBLIC_UPSTASH_REDIS_REST_URL=XXX
-NEXT_PUBLIC_UPSTASH_REDIS_REST_TOKEN=XXX
-```
+## 2. Configuration
 
-## 3. Add a client component in your app:
+### Environment Variables
+Configure your Upstash Redis REST URL and token as environment variables:
+
+```sh-session
+NEXT_PUBLIC_UPSTASH_REDIS_REST_URL=YOUR_REDIS_REST_URL
+NEXT_PUBLIC_UPSTASH_REDIS_REST_TOKEN=YOUR_REDIS_REST_TOKEN
+```
+## 3. Usage
+### Creating the Data Browser Component
+
+In your React application, create a new component that will utilize @upstash/react-databrowser.
+
+Here's a basic example of how to use the component:
 
 ```tsx
-// /app/components/databrowser.tsx
+// /app/components/DatabrowserDemo.tsx
 
-"use client";
 import { Databrowser } from "@upstash/react-databrowser";
 import "@upstash/react-databrowser/dist/index.css";
 
 export default function DatabrowserDemo() {
+  const redisUrl = process.env.NEXT_PUBLIC_UPSTASH_REDIS_REST_URL;
+  const redisToken = process.env.NEXT_PUBLIC_UPSTASH_REDIS_REST_TOKEN;
+
   return (
-    <main
-      style={{
-        height: "100vh",
-        width: "100vw",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        flexDirection: "column",
-        background: "rgb(250,250,250)",
-      }}
-    >
-      <div
-        style={{
-          height: "100%",
-          width: "100%",
-          maxHeight: "45rem",
-          maxWidth: "64rem",
-          borderRadius: "0.5rem",
-          overflow: "hidden",
-        }}
-      >
-        <Databrowser />
+    <main style={mainStyle}>
+      <div style={divStyle}>
+        <Databrowser token={redisToken} url={redisUrl}/>
       </div>
     </main>
   );
 }
+
+// Example CSS-in-JS styling
+const mainStyle = {
+  height: "100vh",
+  width: "100vw",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  flexDirection: "column",
+  background: "rgb(250,250,250)",
+};
+
+const divStyle = {
+  height: "100%",
+  width: "100%",
+  maxHeight: "45rem",
+  maxWidth: "64rem",
+  borderRadius: "0.5rem",
+  overflow: "hidden",
+};
 
 ```

--- a/packages/react-databrowser/package.json
+++ b/packages/react-databrowser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@upstash/react-databrowser",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "license": "MIT",

--- a/packages/react-databrowser/src/components/databrowser/hooks/useAddData.ts
+++ b/packages/react-databrowser/src/components/databrowser/hooks/useAddData.ts
@@ -1,9 +1,12 @@
-import { redis, queryClient } from "@/lib/clients";
+import { queryClient } from "@/lib/clients";
+import { useDatabrowser } from "@/store";
 import { useMutation } from "react-query";
 
 const SUCCESS_MSG = "OK";
 
 export const useAddData = () => {
+  const { redis } = useDatabrowser();
+
   const addData = useMutation(
     async ([dataKey, dataValue, ex]: [dataKey: string, dataValue: string, ex: number | null]) => {
       const res = await redis.set(dataKey, dataValue, { ...(ex ? { ex } : { keepTtl: true }) });

--- a/packages/react-databrowser/src/components/databrowser/hooks/useDeleteKey.ts
+++ b/packages/react-databrowser/src/components/databrowser/hooks/useDeleteKey.ts
@@ -1,7 +1,10 @@
-import { redis, queryClient } from "@/lib/clients";
+import { queryClient } from "@/lib/clients";
+import { useDatabrowser } from "@/store";
 import { useMutation } from "react-query";
 
 export const useDeleteKey = () => {
+  const { redis } = useDatabrowser();
+
   const deleteKey = useMutation(
     async (dataKey?: string) => {
       if (!dataKey) throw new Error("Key is missing!");

--- a/packages/react-databrowser/src/components/databrowser/hooks/useFetchPaginatedKeys.ts
+++ b/packages/react-databrowser/src/components/databrowser/hooks/useFetchPaginatedKeys.ts
@@ -1,9 +1,9 @@
-import { redis } from "@/lib/clients";
 import { zip } from "@/lib/utils";
 import { RedisDataTypeUnion } from "@/types";
 import { useCallback, useRef, useState } from "react";
 import { useQuery } from "react-query";
 import { useDebounce } from "./useDebounce";
+import { useDatabrowser } from "@/store";
 
 const DEFAULT_FETCH_COUNT = 10;
 const INITIAL_CURSOR_NUM = 0;
@@ -11,6 +11,8 @@ const SCAN_MATCH_ALL = "*";
 const DEBOUNCE_TIME = 250;
 
 export const useFetchPaginatedKeys = (dataType?: RedisDataTypeUnion) => {
+  const { redis } = useDatabrowser();
+
   const [timestamp, setTimestamp] = useState(Date.now());
   const cursorStack = useRef([INITIAL_CURSOR_NUM]);
   const [currentIndex, setCurrentIndex] = useState(INITIAL_CURSOR_NUM);

--- a/packages/react-databrowser/src/components/databrowser/hooks/useFetchSingleDataByKey.ts
+++ b/packages/react-databrowser/src/components/databrowser/hooks/useFetchSingleDataByKey.ts
@@ -1,4 +1,4 @@
-import { redis } from "@/lib/clients";
+import { useDatabrowser } from "@/store";
 import { RedisDataTypeUnion } from "@/types";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useQuery } from "react-query";
@@ -16,6 +16,8 @@ export type Navigation = {
 };
 
 export const useFetchSingleDataByKey = (selectedDataKeyTypePair: [string, RedisDataTypeUnion]) => {
+  const { redis } = useDatabrowser();
+
   const cursorStack = useRef([INITIAL_CURSOR_NUM]);
   const listLength = useRef(INITIAL_CURSOR_NUM);
   const [currentIndex, setCurrentIndex] = useState(INITIAL_CURSOR_NUM);

--- a/packages/react-databrowser/src/components/databrowser/hooks/useFetchTTLBy.ts
+++ b/packages/react-databrowser/src/components/databrowser/hooks/useFetchTTLBy.ts
@@ -1,7 +1,9 @@
-import { redis } from "@/lib/clients";
+import { useDatabrowser } from "@/store";
 import { useQuery } from "react-query";
 
 export const useFetchTTLByKey = (dataKey?: string) => {
+  const { redis } = useDatabrowser();
+
   const { isLoading, error, data } = useQuery({
     queryKey: ["useFetchTTLByKey", dataKey],
     queryFn: async () => {

--- a/packages/react-databrowser/src/components/databrowser/hooks/useUpdateTTL.ts
+++ b/packages/react-databrowser/src/components/databrowser/hooks/useUpdateTTL.ts
@@ -1,7 +1,10 @@
-import { redis, queryClient } from "@/lib/clients";
+import { queryClient } from "@/lib/clients";
+import { useDatabrowser } from "@/store";
 import { useMutation } from "react-query";
 
 export const useUpdateTTL = () => {
+  const { redis } = useDatabrowser();
+
   const updateTTL = useMutation(
     async ({ dataKey, newTTLValue }: { dataKey?: string; newTTLValue: number }) => {
       if (!dataKey) throw new Error("Key is missing!");
@@ -18,6 +21,8 @@ export const useUpdateTTL = () => {
 };
 
 export const usePersistTTL = () => {
+  const { redis } = useDatabrowser();
+
   const persistTTL = useMutation(
     async (dataKey?: string) => {
       if (!dataKey) throw new Error("Key is missing!");

--- a/packages/react-databrowser/src/components/databrowser/index.tsx
+++ b/packages/react-databrowser/src/components/databrowser/index.tsx
@@ -1,14 +1,15 @@
+import { queryClient } from "@/lib/clients";
+import { DatabrowserProps, DatabrowserProvider } from "@/store";
 import { RedisDataTypeUnion } from "@/types";
 import { useState } from "react";
-import { QueryClient, QueryClientProvider } from "react-query";
+import { QueryClientProvider } from "react-query";
 import { Toaster } from "../ui/toaster";
+import { AddDataDialog } from "./components/add-data/add-data-dialog";
 import { DataDisplayContainer } from "./components/data-display-container";
 import { Sidebar } from "./components/sidebar";
-import { AddDataDialog } from "./components/add-data/add-data-dialog";
 import "@/globals.css";
-import { queryClient } from "@/lib/clients";
 
-export const Databrowser = () => {
+export const Databrowser = ({ token, url }: DatabrowserProps) => {
   const [selectedDataKey, setSelectedDataKey] = useState<[string, RedisDataTypeUnion] | undefined>();
 
   const handleDataKeySelect = (dataKey?: [string, RedisDataTypeUnion]) => {
@@ -16,19 +17,21 @@ export const Databrowser = () => {
   };
 
   return (
-    <QueryClientProvider client={queryClient}>
-      <div className="flex flex-col gap-4">
-        <div className="ml-auto">
-          <AddDataDialog onNewDataAdd={handleDataKeySelect} />
-        </div>
-        <div className="overflow-hidden rounded-[0.5rem] border shadow">
-          <div className="grid text-ellipsis lg:grid-cols-[1.5fr,1.2fr,1fr,1fr,1fr]">
-            <Sidebar selectedDataKey={selectedDataKey?.[0]} onDataKeyChange={handleDataKeySelect} />
-            <DataDisplayContainer selectedDataKeyTypePair={selectedDataKey} onDataKeyChange={handleDataKeySelect} />
-            <Toaster />
+    <DatabrowserProvider databrowser={{ token, url }}>
+      <QueryClientProvider client={queryClient}>
+        <div className="flex flex-col gap-4">
+          <div className="ml-auto">
+            <AddDataDialog onNewDataAdd={handleDataKeySelect} />
+          </div>
+          <div className="overflow-hidden rounded-[0.5rem] border shadow">
+            <div className="grid text-ellipsis lg:grid-cols-[1.5fr,1.2fr,1fr,1fr,1fr]">
+              <Sidebar selectedDataKey={selectedDataKey?.[0]} onDataKeyChange={handleDataKeySelect} />
+              <DataDisplayContainer selectedDataKeyTypePair={selectedDataKey} onDataKeyChange={handleDataKeySelect} />
+              <Toaster />
+            </div>
           </div>
         </div>
-      </div>
-    </QueryClientProvider>
+      </QueryClientProvider>
+    </DatabrowserProvider>
   );
 };

--- a/packages/react-databrowser/src/lib/clients.ts
+++ b/packages/react-databrowser/src/lib/clients.ts
@@ -1,14 +1,17 @@
+import { DatabrowserProps } from "@/store";
 import { Redis } from "@upstash/redis";
 import { QueryClient } from "react-query";
 
-const initializeRedis = () => {
-  if (!process.env.NEXT_PUBLIC_UPSTASH_REDIS_REST_URL) throw new Error("NEXT_PUBLIC_UPSTASH_REDIS_REST_URL is missing");
-  if (!process.env.NEXT_PUBLIC_UPSTASH_REDIS_REST_TOKEN)
-    throw new Error("NEXT_PUBLIC_UPSTASH_REDIS_REST_TOKEN is missing");
+export const redisClient = (databrowser?: DatabrowserProps) => {
+  const token = databrowser?.token || process.env.NEXT_PUBLIC_UPSTASH_REDIS_REST_TOKEN;
+  const url = databrowser?.url || process.env.NEXT_PUBLIC_UPSTASH_REDIS_REST_URL;
+
+  if (!url) throw new Error("Redis URL is missing!");
+  if (!token) throw new Error("Redis TOKEN is missing!");
 
   const redis = new Redis({
-    url: process.env.NEXT_PUBLIC_UPSTASH_REDIS_REST_URL,
-    token: process.env.NEXT_PUBLIC_UPSTASH_REDIS_REST_TOKEN,
+    url,
+    token,
   });
 
   return redis;
@@ -45,5 +48,3 @@ export const queryClient = new QueryClient({
     },
   },
 });
-
-export const redis = initializeRedis();

--- a/packages/react-databrowser/src/playground.tsx
+++ b/packages/react-databrowser/src/playground.tsx
@@ -25,7 +25,10 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
           overflow: "hidden",
         }}
       >
-        <Databrowser />
+        <Databrowser
+          token={process.env.NEXT_PUBLIC_UPSTASH_REDIS_REST_TOKEN}
+          url={process.env.NEXT_PUBLIC_UPSTASH_REDIS_REST_URL}
+        />
       </div>
     </main>
   </React.StrictMode>,

--- a/packages/react-databrowser/src/store.tsx
+++ b/packages/react-databrowser/src/store.tsx
@@ -1,0 +1,31 @@
+import { PropsWithChildren, createContext, useContext, useMemo } from "react";
+import { Redis } from "@upstash/redis";
+import { redisClient } from "./lib/clients";
+
+export type DatabrowserProps = {
+  url?: string;
+  token?: string;
+};
+
+type DatabrowserContextProps = {
+  redis: Redis;
+};
+
+const DatabrowserContext = createContext<DatabrowserContextProps | undefined>(undefined);
+
+interface DatabrowserProviderProps {
+  databrowser: DatabrowserProps;
+}
+
+export const DatabrowserProvider = ({ children, databrowser }: PropsWithChildren<DatabrowserProviderProps>) => {
+  const redisInstances = useMemo(() => redisClient(databrowser), [databrowser.token, databrowser.url]);
+  return <DatabrowserContext.Provider value={{ redis: redisInstances }}>{children}</DatabrowserContext.Provider>;
+};
+
+export const useDatabrowser = (): DatabrowserContextProps => {
+  const context = useContext(DatabrowserContext);
+  if (!context) {
+    throw new Error("useDatabrowser must be used within a DatabrowserProvider");
+  }
+  return context;
+};


### PR DESCRIPTION
- Instantiating redis client via context then passing it down to use with other query and mutation hooks.