### PR TITLE
Add Vite to enable standalone mode in the CLI

### DIFF
--- a/.changeset/ninety-masks-smoke.md
+++ b/.changeset/ninety-masks-smoke.md
@@ -1,0 +1,5 @@
+---
+"@upstash/react-cli": patch
+---
+
+Add Vite to enable standalone mode in the CLI

--- a/packages/react-cli/index.html
+++ b/packages/react-cli/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CLI Playground</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/playground.tsx"></script>
+  </body>
+</html>

--- a/packages/react-cli/package.json
+++ b/packages/react-cli/package.json
@@ -14,7 +14,8 @@
   ],
   "author": "Andreas Thomas <andreas@upstash.com>",
   "scripts": {
-    "build": "tsup"
+    "build": "tsup",
+    "dev": "vite"
   },
   "devDependencies": {
     "@types/node": "^18.15.11",
@@ -26,7 +27,9 @@
     "react-dom": "^18.2.0",
     "tailwindcss": "^3.3.1",
     "tsup": "^6.7.0",
-    "typescript": "^5.0.4"
+    "typescript": "^5.0.4",
+    "@vitejs/plugin-react": "^4.1.0",
+    "vite": "^4.4.10"
   },
   "peerDependencies": {
     "react": "^18.2.0",

--- a/packages/react-cli/src/playground.tsx
+++ b/packages/react-cli/src/playground.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { RedisCli } from "./redis-cli";
+import "./cli.css";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <main
+      style={{
+        height: "100vh",
+        width: "100vw",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        flexDirection: "column",
+        background: "rgb(250,250,250)",
+      }}
+    >
+      <div
+        style={{
+          height: "100%",
+          width: "100%",
+          maxHeight: "32rem",
+          maxWidth: "48rem",
+          borderRadius: "0.5rem",
+          overflow: "hidden",
+        }}
+      >
+        <RedisCli
+          token={process.env.NEXT_PUBLIC_UPSTASH_REDIS_REST_TOKEN!}
+          url={process.env.NEXT_PUBLIC_UPSTASH_REDIS_REST_URL!}
+        />
+      </div>
+    </main>
+  </React.StrictMode>,
+);

--- a/packages/react-cli/tsconfig.json
+++ b/packages/react-cli/tsconfig.json
@@ -13,7 +13,7 @@
     /* Language and Environment */
     "target": "ESNext",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
-     "jsx": "react",                                /* Specify what JSX code is generated. */
+    "jsx": "react-jsx",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
     // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
     // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */

--- a/packages/react-cli/vite.config.ts
+++ b/packages/react-cli/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig, loadEnv } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default ({ mode }: { mode: string }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+  return defineConfig({
+    define: {
+      "process.env": env,
+    },
+    plugins: [react()],
+  });
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,6 +94,9 @@ importers:
       '@types/react-dom':
         specifier: ^18.0.11
         version: 18.0.11
+      '@vitejs/plugin-react':
+        specifier: ^4.1.0
+        version: 4.1.0(vite@4.4.10)
       autoprefixer:
         specifier: ^10.4.14
         version: 10.4.14(postcss@8.4.22)
@@ -115,6 +118,9 @@ importers:
       typescript:
         specifier: ^5.0.4
         version: 5.0.4
+      vite:
+        specifier: ^4.4.10
+        version: 4.4.10(@types/node@18.15.11)
 
   packages/react-databrowser:
     dependencies:


### PR DESCRIPTION
Integrate Vite with the CLI to enable previews in standalone without requiring a build each time.