### PR TITLE
parse rawData twice to make sure that we get the JSON object

### DIFF
--- a/packages/react-databrowser/src/components/databrowser/components/data-display-container/display-scrollarea.tsx
+++ b/packages/react-databrowser/src/components/databrowser/components/data-display-container/display-scrollarea.tsx
@@ -60,7 +60,7 @@ export const prettifyData = (data: string) => {
 
 const rawToObject = (rawData: string) => {
   try {
-    return JSON.parse(rawData);
+    return JSON.parse(JSON.parse(rawData));
   } catch (_error) {
     return rawData;
   }


### PR DESCRIPTION
consider the following string `"{\"a\":2,\"b\":4,\"c\":6}"`. When JSON.parse is called on this string, we get `"{"a":2,"b":4,"c":6}"`, but here is the catch: this is a string. So we have to run JSON.parse twice to get the actual object :clown_face:

This caused the JSON on the data browser to be shown as a string as opposed to a prettified JSON.

See this SO post for more details https://stackoverflow.com/questions/42494823/json-parse-returns-string-instead-of-object

Fixed from:

<img width="900" alt="image" src="https://github.com/upstash/react-ui/assets/57228345/4290b0ee-cbdf-4683-a14c-1735013a8348">

To

<img width="900" alt="image" src="https://github.com/upstash/react-ui/assets/57228345/bd2db165-d45e-4f5b-9f2a-27bcfc8a1345">
