### PR TITLE
Call toast with error message on fetch error

### DIFF
--- a/.changeset/lovely-feet-juggle.md
+++ b/.changeset/lovely-feet-juggle.md
@@ -1,0 +1,5 @@
+---
+"@upstash/react-databrowser": patch
+---
+
+Show toast on error when fetching keys

--- a/.changeset/lovely-feet-juggle.md
+++ b/.changeset/lovely-feet-juggle.md
@@ -2,4 +2,4 @@
 "@upstash/react-databrowser": patch
 ---
 
-Show toast on error when fetching keys
+Log all fetch errors to console

--- a/packages/react-databrowser/src/components/databrowser/hooks/useFetchPaginatedKeys.ts
+++ b/packages/react-databrowser/src/components/databrowser/hooks/useFetchPaginatedKeys.ts
@@ -5,6 +5,7 @@ import { useCallback, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useDebounce } from "./useDebounce";
 import type { Redis } from "@upstash/redis";
+import { toast } from "@/components/ui/use-toast";
 
 const SCAN_MATCH_ALL = "*";
 const DEBOUNCE_TIME = 250;
@@ -187,6 +188,14 @@ export const useFetchPaginatedKeys = (dataType?: RedisDataTypeUnion) => {
     typeFilter: allTypesIncluded,
     page: currentPage,
   });
+
+  if (error) {
+    toast({
+      variant: "destructive",
+      title: "Uh oh! Something went wrong.",
+      description: `There was a problem when loading Redis data. Received Error: ${error}`,
+    });
+  }
 
   const handlePageChange = useCallback(
     (dir: "next" | "prev") => {

--- a/packages/react-databrowser/src/components/databrowser/hooks/useFetchPaginatedKeys.ts
+++ b/packages/react-databrowser/src/components/databrowser/hooks/useFetchPaginatedKeys.ts
@@ -5,7 +5,6 @@ import { useCallback, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useDebounce } from "./useDebounce";
 import type { Redis } from "@upstash/redis";
-import { toast } from "@/components/ui/use-toast";
 
 const SCAN_MATCH_ALL = "*";
 const DEBOUNCE_TIME = 250;
@@ -188,14 +187,6 @@ export const useFetchPaginatedKeys = (dataType?: RedisDataTypeUnion) => {
     typeFilter: allTypesIncluded,
     page: currentPage,
   });
-
-  if (error) {
-    toast({
-      variant: "destructive",
-      title: "Uh oh! Something went wrong.",
-      description: `There was a problem when loading Redis data. Received Error: ${error}`,
-    });
-  }
 
   const handlePageChange = useCallback(
     (dir: "next" | "prev") => {

--- a/packages/react-databrowser/src/lib/clients.ts
+++ b/packages/react-databrowser/src/lib/clients.ts
@@ -71,9 +71,8 @@ export const queryClient = new QueryClient({
           title: "Error",
           description: desc,
         });
-
-        console.error(error);
       }
+      console.error(error);
     },
   }),
 });


### PR DESCRIPTION
databrowser simply shows SidebarMissingData when there is an error which complicates debugging the issues. This was an issue when we debugged the case when two integer keys were compared. It's also a problem in a recent ticket.

This change adds a toast when there is an error. This will show the error text to the user who can share it with us.