### PR TITLE
fix: disable sorting arrays

### DIFF
--- a/packages/react-databrowser/src/components/databrowser/components/data-display-container/display-scrollarea.tsx
+++ b/packages/react-databrowser/src/components/databrowser/components/data-display-container/display-scrollarea.tsx
@@ -91,11 +91,7 @@ const sortObject = (unordered: [] | Record<string, any> | null, sortArrays = fal
   }
 
   if (Array.isArray(unordered)) {
-    const newArr: unknown[] = unordered.map((item) => sortObject(item, sortArrays));
-    if (sortArrays) {
-      newArr.sort();
-    }
-    return newArr;
+    return unordered;
   }
 
   // biome-ignore lint/suspicious/noExplicitAny: <explanation>


### PR DESCRIPTION
when the data is `foo: [2, 1]`, we sort it as `foo: [1, 2]` which is misleading

this pr disables sorting arrays 