### PR TITLE
fix: add keepAlive: false back

### DIFF
--- a/.changeset/rich-papayas-cover.md
+++ b/.changeset/rich-papayas-cover.md
@@ -1,0 +1,5 @@
+---
+"@upstash/react-databrowser": patch
+---
+
+add keepAlive:false back

--- a/packages/react-databrowser/src/lib/clients.ts
+++ b/packages/react-databrowser/src/lib/clients.ts
@@ -19,6 +19,7 @@ export const redisClient = (databrowser?: DatabrowserProps) => {
     token,
     enableAutoPipelining: true,
     automaticDeserialization: false,
+    keepAlive: false,
   });
 
   return redis;


### PR DESCRIPTION
this parameter was added to enable large payloads in data browser. More information is available in https://github.com/upstash/react-ui/pull/84.

It was removed unintentionally https://github.com/upstash/react-ui/pull/91